### PR TITLE
Fix user exclusion logic in profile search

### DIFF
--- a/ToolkitCleanup/Program.cs
+++ b/ToolkitCleanup/Program.cs
@@ -1508,7 +1508,7 @@ namespace ToolkitCleanup
                 }
             }
 
-            ObjectQuery query = new ObjectQuery($"SELECT * FROM Win32_UserProfile Where Special = false And Not LocalPath Like \"%Admin%\"{(string.IsNullOrWhiteSpace(username) ? " And Not LocalPath Like \"%{username}%\"" : "")}");
+            ObjectQuery query = new ObjectQuery($"SELECT * FROM Win32_UserProfile Where Special = false And Not LocalPath Like \"%Admin%\"{(!string.IsNullOrWhiteSpace(username) ? " And Not LocalPath Like \"%{username}%\"" : "")}");
             using ManagementObjectSearcher searcher = new ManagementObjectSearcher(scope, query);
             if (searcher != null)
             {


### PR DESCRIPTION
## Summary
- fix boolean expression when excluding specific usernames

## Testing
- `dotnet build ToolkitCleanup.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68857ce72a7483219d4d936e70a1619c