### PR TITLE
Fix permissions error wording

### DIFF
--- a/ToolkitCleanup/Program.cs
+++ b/ToolkitCleanup/Program.cs
@@ -1490,7 +1490,7 @@ namespace ToolkitCleanup
                         StopSequenceThread = true;
                         Console.Clear();
                         ConsoleWriter cw = new ConsoleWriter();
-                        cw.WriteLineAnimated("We have ran into a permissions error.", 30)
+                        cw.WriteLineAnimated("We have run into a permissions error.", 30)
                             .WriteLineAnimated("Please relaunch this script with necessary credentials.", 30)
                             .WriteLineAnimated("", 0)
                             .WriteLineAnimated("Press any key to exit.", 30);


### PR DESCRIPTION
## Summary
- correct `We have ran into a permissions error` to `We have run into a permissions error` in `Program.cs`

## Testing
- `grep -R "permissions error" -n`


------
https://chatgpt.com/codex/tasks/task_e_68858fcf68c083218ae8539e1f1f6e39