### PR TITLE
Fix username condition in GetProfileInfoDat

### DIFF
--- a/ToolkitCleanup/Program.cs
+++ b/ToolkitCleanup/Program.cs
@@ -1508,7 +1508,7 @@ namespace ToolkitCleanup
                 }
             }
 
-            ObjectQuery query = new ObjectQuery($"SELECT * FROM Win32_UserProfile Where Special = false And Not LocalPath Like \"%Admin%\"{(!string.IsNullOrWhiteSpace(username) ? " And Not LocalPath Like \"%{username}%\"" : "")}");
+            ObjectQuery query = new ObjectQuery($"SELECT * FROM Win32_UserProfile Where Special = false And Not LocalPath Like \"%Admin%\"{(!string.IsNullOrWhiteSpace(username) ? $" And Not LocalPath Like \"%{username}%\"" : "")}");
             using ManagementObjectSearcher searcher = new ManagementObjectSearcher(scope, query);
             if (searcher != null)
             {


### PR DESCRIPTION
## Summary
- ensure username filter only applies when a username is given

## Testing
- `dotnet test ToolkitCleanup.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68858fd9525c8321a33b87fb630d7564