### PR TITLE
Fix help syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Command-Line parameters:
     -Computer:<computername>
     -User:<username>
     -Pass:<password>
-    -Clean <cleanType>
+    -Clean:<cleanType>
     <CleanType>:0 = Main Menu Choices,
     <CleanType>:1 = Full Auto Clean
     <CleanType>:2 = Full Prompt Clean

--- a/ToolkitCleanup/Program.cs
+++ b/ToolkitCleanup/Program.cs
@@ -108,7 +108,7 @@ namespace ToolkitCleanup
                         Console.WriteLine("-Computer:<computername>");
                         Console.WriteLine("-User:<username>");
                         Console.WriteLine("-Pass:<password>");
-                        Console.WriteLine("-Clean <cleanType>");
+                        Console.WriteLine("-Clean:<cleanType>");
                         Console.WriteLine("<CleanType>:0 = Main Menu Choices,");
                         Console.WriteLine("<CleanType>:1 = Full Auto Clean, 2 = Full Prompt Clean, 3 = Old Profile Removal w/Prompt,");
                         Console.WriteLine("<CleanType>:4 = PC Temp Cleanup, 5 = User Temp Cleanup, 6 = PC & User Temp Cleanup");


### PR DESCRIPTION
## Summary
- fix syntax in Program.cs help output for -Clean option
- keep README parameters consistent with new syntax

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68858fdf812c8321a86c85ca9c527206