### PR TITLE
Add xUnit tests for CryptoTools

### DIFF
--- a/ToolkitCleanup.Tests/CryptoToolsTests.cs
+++ b/ToolkitCleanup.Tests/CryptoToolsTests.cs
@@ -1,0 +1,57 @@
+using Xunit;
+
+namespace ToolkitCleanup.Tests
+{
+    public class CryptoToolsTests
+    {
+        private const string Secret = "test-secret";
+
+        [Fact]
+        public void EncryptThenDecrypt_ReturnsOriginalString()
+        {
+            string original = "Hello, World!";
+            string encrypted = Crypto.EncryptStringAES(original, Secret);
+            string decrypted = Crypto.DecryptStringAES(encrypted, Secret);
+
+            Assert.Equal(original, decrypted);
+        }
+
+        [Fact]
+        public void EncryptStringAES_NullInput_ReturnsNull()
+        {
+            string result = Crypto.EncryptStringAES(null, Secret);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void EncryptStringAES_EmptyInput_ReturnsNull()
+        {
+            string result = Crypto.EncryptStringAES(string.Empty, Secret);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void DecryptStringAES_NullInput_ReturnsNull()
+        {
+            string result = Crypto.DecryptStringAES(null, Secret);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void DecryptStringAES_EmptyInput_ReturnsNull()
+        {
+            string result = Crypto.DecryptStringAES(string.Empty, Secret);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void EncryptDecrypt_NullSecret_ReturnsNull()
+        {
+            string resultEncrypt = Crypto.EncryptStringAES("data", null);
+            string resultDecrypt = Crypto.DecryptStringAES("cipher", null);
+
+            Assert.Null(resultEncrypt);
+            Assert.Null(resultDecrypt);
+        }
+    }
+}

--- a/ToolkitCleanup.Tests/ToolkitCleanup.Tests.csproj
+++ b/ToolkitCleanup.Tests/ToolkitCleanup.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="../ToolkitCleanup/Modified Assistant Classes/CryptoTools.cs" Link="CryptoTools.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add a new xUnit test project
- implement roundtrip and edge case tests for AES encrypt/decrypt

## Testing
- `dotnet test ToolkitCleanup.Tests/ToolkitCleanup.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68858ff112fc8321962b722afd509d97