### PR TITLE
Update cleanup utility for Windows 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
  # ToolkitCleanup
 ![Icon](https://github.com/cloudd901/ToolkitCleanup/blob/master/ToolkitCleanup/logo.ico)
 
-Toolkit Cleanup script was made as part of a Computer Toolkit application. The script itself is standalone and can be used on any Windows 7, 8, or 10 device.
+Toolkit Cleanup script was made as part of a Computer Toolkit application. The script itself is standalone and can be used on any Windows 7, 8, 10, or 11 device.
 
  - Designed to scour all corners of multi-user workstations.
  - Can compare dates and remove old account profiles.
@@ -59,6 +59,9 @@ Removes files from the following folders:
     "C:\Users\<USERNAME>\AppData\Local\Packages\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\AC\*"
     "C:\Users\<USERNAME>\AppData\Local\Packages\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\LocalCache\*"
     "C:\Users\<USERNAME>\AppData\Local\Packages\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\AppData\User\Default\CacheStorage\*"
+    "C:\Users\<USERNAME>\AppData\Local\Microsoft\Edge\User Data\Default\Cache\*"
+    "C:\Users\<USERNAME>\AppData\Local\Microsoft\Edge\User Data\Default\Cookies\*"
+    "C:\Users\<USERNAME>\AppData\Local\Microsoft\Edge\User Data\Default\History\*"
     "C:\Users\<USERNAME>\AppData\Local\Chromium\User Data\Default\Cache\*"
     "C:\Users\<USERNAME>\AppData\Local\Chromium\User Data\Default\GPUCache\*"
     "C:\Users\<USERNAME>\AppData\Local\Chromium\User Data\ShaderCache\*"

--- a/ToolkitCleanup/Program.cs
+++ b/ToolkitCleanup/Program.cs
@@ -25,7 +25,7 @@ namespace ToolkitCleanup
             null
         };
 
-        public static string[] FolderListUser = new string[31]
+        public static string[] FolderListUser = new string[34]
         {
             @"C:\Users\<USERNAME>\AppData\Roaming\Microsoft\Teams\tmp\*",
             @"C:\Users\<USERNAME>\AppData\Roaming\Microsoft\Teams\blob_storage\*",
@@ -55,6 +55,9 @@ namespace ToolkitCleanup
             @"C:\Users\<USERNAME>\AppData\Local\Packages\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\AC\*",
             @"C:\Users\<USERNAME>\AppData\Local\Packages\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\LocalCache\*",
             @"C:\Users\<USERNAME>\AppData\Local\Packages\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\AppData\User\Default\CacheStorage\*",
+            @"C:\Users\<USERNAME>\AppData\Local\Microsoft\Edge\User Data\Default\Cache\*",
+            @"C:\Users\<USERNAME>\AppData\Local\Microsoft\Edge\User Data\Default\Cookies\*",
+            @"C:\Users\<USERNAME>\AppData\Local\Microsoft\Edge\User Data\Default\History\*",
             @"C:\Users\<USERNAME>\AppData\Local\Chromium\User Data\Default\Cache\*",
             @"C:\Users\<USERNAME>\AppData\Local\Chromium\User Data\Default\GPUCache\*",
             @"C:\Users\<USERNAME>\AppData\Local\Chromium\User Data\ShaderCache\*"

--- a/ToolkitCleanup/app.manifest
+++ b/ToolkitCleanup/app.manifest
@@ -39,7 +39,7 @@
       <!-- Windows 8.1 -->
       <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
 
-      <!-- Windows 10 -->
+      <!-- Windows 10 / Windows 11 -->
       <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
 
     </application>


### PR DESCRIPTION
## Summary
- include Windows 11 in documentation and manifest
- add new Microsoft Edge cleanup paths for Windows 11

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68859164f8f083219df4f09ac80c4158